### PR TITLE
Avoid deprecated syntax

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/prettyprinters/Enquote.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/prettyprinters/Enquote.scala
@@ -23,7 +23,7 @@ object enquote {
         case '\\' => sb.append("\\\\")
         case '"' if style eq DoubleQuotes =>
           sb.append("\\\"")
-        case ''' if style eq SingleQuotes =>
+        case '\'' if style eq SingleQuotes =>
           sb.append("\\\'")
         case c =>
           sb.append(c)


### PR DESCRIPTION
This project has failed in the community build recently, I think after the syntax deprecation was added.

```
[scalameta] [info] Done packaging.
[scalameta] [info] Done updating.
[scalameta] [info] Compiling 55 Scala sources to /home/jenkins/workspace/scala-2.12.x-integrate-community-build/target-0.9.7/project-builds/scalameta-189972fdc250de46822f0547be071a01e0b916be/scalameta/common/jvm/target/scala-2.12/classes...
[scalameta] [info] Main Scala API documentation to /home/jenkins/workspace/scala-2.12.x-integrate-community-build/target-0.9.7/project-builds/scalameta-189972fdc250de46822f0547be071a01e0b916be/scalameta/common/jvm/target/scala-2.12/api...
[scalameta] [error] /home/jenkins/workspace/scala-2.12.x-integrate-community-build/target-0.9.7/project-builds/scalameta-189972fdc250de46822f0547be071a01e0b916be/scalameta/common/shared/src/main/scala/scala/meta/internal/prettyprinters/Enquote.scala:26: deprecated syntax for character literal (use '\'' for single quote)
[scalameta] [error]         case ''' if style eq SingleQuotes =>
[scalameta] [error]              ^
[scalameta] [error] /home/jenkins/workspace/scala-2.12.x-integrate-community-build/target-0.9.7/project-builds/scalameta-189972fdc250de46822f0547be071a01e0b916be/scalameta/common/shared/src/main/scala/scala/meta/internal/prettyprinters/Enquote.scala:26: deprecated syntax for character literal (use '\'' for single quote)
[scalameta] [error]         case ''' if style eq SingleQuotes =>
[scalameta] [error]              ^
[scalameta] [error] one error found
[scalameta] [info] No documentation generated with unsuccessful compiler run
[scalameta] [error] one error found
[scalameta] [error] (commonJVM/compile:doc) Scaladoc generation failed
[scalameta] [error] (commonJVM/compile:compileIncremental) Compilation failed
```

Good old `-Xfatal-warnings`